### PR TITLE
Updated react-beautiful-dnd dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
     "prop-types": "^15.6.2",
-    "react-beautiful-dnd": "11.0.3",
+    "react-beautiful-dnd": "^13.0.0",
     "react-double-scrollbar": "0.0.15"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Related Issue
#2066

## Description
Updated `react-beautiful-dnd` to version `^13.0.0`. This version has the possibility of adding a `cspNonce` which the current version `11.0.3` does not have.

## Related PRs
In this PR #1438 , the possibility of adding a `cspNonce` to `material-table` options was added but it is not woring because of outdated `react-beautiful-dnd`.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* No direct implication in the components